### PR TITLE
Remove space between quotes in the title of the Create Page dialog box

### DIFF
--- a/src/components/learn/NewSectionModal.tsx
+++ b/src/components/learn/NewSectionModal.tsx
@@ -95,7 +95,7 @@ export default function NewSectionModal({
   return (
     <>
       <Modal
-        title={`Add new section under ' ${parentSection.title}'`}
+        title={`Add new section under '${parentSection.title}'`}
         visible={show}
         onOk={() => form.submit()}
         onCancel={() => setShow(false)}


### PR DESCRIPTION
 This is related to the issue #60 