### PR TITLE
Fixed Allow user to type in topic, instead of just selecting #112

### DIFF
--- a/src/pages/resources/new.tsx
+++ b/src/pages/resources/new.tsx
@@ -110,7 +110,15 @@ export default function CreateResource() {
         </Form.Item>
 
         <Form.Item name={'topic'} label={'Topic'} rules={[{ required: true }]}>
-          <Select placeholder={'Select a topic for the resource'}>
+          <Select
+            showSearch
+            placeholder={'Select a topic for the resource'}
+            filterOption={(input, option) =>
+              option?.props.children
+                .toLowerCase()
+                .indexOf(input.toLowerCase()) >= 0
+            }
+          >
             {topicsData.topics.map((topic: Topic) => (
               <Select.Option key={topic.id} value={topic.id}>
                 {topic.title}


### PR DESCRIPTION
When creating a new resource, user is now able to type their topic and the dropdown act as search results for every key entered.